### PR TITLE
Make memory_limit_bytes available as optional bosh property

### DIFF
--- a/jobs/log-cache/spec
+++ b/jobs/log-cache/spec
@@ -43,6 +43,9 @@ properties:
     description: "Percentage of system memory to use for the cache. Must be an integer."
     default: 50
 
+  memory_limit_bytes:
+    description: "Overrides memory_limit_percent with a specific size cache in bytes."
+
   max_per_source:
     description: "The maximum number of items stored in LogCache per source."
     default: 100000

--- a/jobs/log-cache/templates/bpm.yml.erb
+++ b/jobs/log-cache/templates/bpm.yml.erb
@@ -25,6 +25,9 @@ processes:
   env:
     ADDR:        "<%= ":#{p('port')}" %>"
     MEMORY_LIMIT_PERCENT: "<%= p('memory_limit_percent') %>"
+<%- if_p('memory_limit_bytes') do |memory_limit_bytes| %>
+    MEMORY_LIMIT_BYTES: "<%= memory_limit_bytes %>"
+<% end -%>
     MAX_PER_SOURCE: "<%= p('max_per_source') %>"
     INGRESS_BUFFER_SIZE: "<%= p('ingress_buffer_size') %>"
     INGRESS_BUFFER_READ_BATCH_SIZE: "<%= p('ingress_buffer_read_batch_size') %>"


### PR DESCRIPTION
# Description
The code allows both a configurable % and byte limit for memory. Specifically the byte limit makes sense when you want to run log-cache on a really large VM, colocated with other things, but you don't want it to take up too much of the VM's memory.

This optional property will do nothing until set, at which point it will override the memory % limit, as documented.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Acceptance tests 

I validated the deployment with the property provided and saw that memory was kept under control to a small amount (tested with 10MB limit, saw log cache grow to ~30MB but then stop... I'm assuming that's a 10MB app logs limit not a total process limit)

I validated the deployment with the property missing and saw the BPM.yml was valid and no longer set the memory limit in bytes at all.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation (via spec)

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
